### PR TITLE
install python into containers for use during mapred

### DIFF
--- a/datanode/Dockerfile
+++ b/datanode/Dockerfile
@@ -1,5 +1,8 @@
 FROM wxwmatt/hadoop-base:2.1.1-hadoop3.3.1-java8
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      python3.6
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 HEALTHCHECK CMD curl -f http://localhost:9864/ || exit 1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3"
 services:
   namenode:
     image: wxwmatt/hadoop-namenode:2.1.1-hadoop3.3.1-java8
+    build:
+      context: namenode
+      dockerfile: Dockerfile
     container_name: namenode
     restart: always
     ports:
@@ -20,6 +23,9 @@ services:
 
   datanode:
     image: wxwmatt/hadoop-datanode:2.1.1-hadoop3.3.1-java8
+    build:
+      context: datanode
+      dockerfile: Dockerfile
     container_name: datanode
     restart: always
     ports:
@@ -33,6 +39,9 @@ services:
 
   resourcemanager:
     image: wxwmatt/hadoop-resourcemanager:2.1.1-hadoop3.3.1-java8
+    build:
+      context: resourcemanager
+      dockerfile: Dockerfile
     container_name: resourcemanager
     restart: always
     ports:
@@ -44,6 +53,9 @@ services:
 
   nodemanager1:
     image: wxwmatt/hadoop-nodemanager:2.1.1-hadoop3.3.1-java8
+    build:
+      context: nodemanager
+      dockerfile: Dockerfile
     container_name: nodemanager
     restart: always
     ports:
@@ -55,6 +67,9 @@ services:
 
   historyserver:
     image: wxwmatt/hadoop-historyserver:2.1.1-hadoop3.3.1-java8
+    build:
+      context: historyserver
+      dockerfile: Dockerfile
     container_name: historyserver
     restart: always
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     environment:
       - CLUSTER_NAME=test
       - HOME=/app
+      - SPARK_HOME=/usr/local/lib/python3.7/dist-packages/pyspark
+      - HIVE_HOME=/hive/apache-hive-3.1.3-bin
     env_file:
       - ./hadoop.env
 
@@ -81,7 +83,20 @@ services:
     env_file:
       - ./hadoop.env
 
+  postgres:
+    image: postgres:latest
+    container_name: postgres13
+    restart: always
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./jobs:/app
+    ports:
+      - '5432:5432'
+    env_file:
+      - ./postgres.env
+
 volumes:
   hadoop_namenode:
   hadoop_datanode:
   hadoop_historyserver:
+  postgres_data:

--- a/historyserver/Dockerfile
+++ b/historyserver/Dockerfile
@@ -1,5 +1,9 @@
 FROM wxwmatt/hadoop-base:2.1.1-hadoop3.3.1-java8
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      python3.6
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
 HEALTHCHECK CMD curl -f http://localhost:8188/ || exit 1
 
 ENV YARN_CONF_yarn_timeline___service_leveldb___timeline___store_path=/hadoop/yarn/timeline

--- a/namenode/Dockerfile
+++ b/namenode/Dockerfile
@@ -1,5 +1,9 @@
 FROM wxwmatt/hadoop-base:2.1.1-hadoop3.3.1-java8
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      python3.6
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
 HEALTHCHECK CMD curl -f http://localhost:9870/ || exit 1
 
 ENV HDFS_CONF_dfs_namenode_name_dir=file:///hadoop/dfs/name

--- a/namenode/Dockerfile
+++ b/namenode/Dockerfile
@@ -1,8 +1,21 @@
 FROM wxwmatt/hadoop-base:2.1.1-hadoop3.3.1-java8
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-      python3.6
+      build-essential \
+      iputils-ping \
+      wget \
+      python3.7-dev \
+      python3.7 \
+      python3-pip
+ 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+RUN pip3 install wheel
+RUN pip3 install setuptools
+RUN pip3 install py4j
+RUN pip3 install pyspark
+RUN pip3 install numpy
+
 
 HEALTHCHECK CMD curl -f http://localhost:9870/ || exit 1
 

--- a/namenode/Dockerfile
+++ b/namenode/Dockerfile
@@ -1,13 +1,16 @@
 FROM wxwmatt/hadoop-base:2.1.1-hadoop3.3.1-java8
 
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       build-essential \
       iputils-ping \
-      wget \
+      wget
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
       python3.7-dev \
       python3.7 \
       python3-pip
- 
+
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 RUN pip3 install wheel
@@ -15,7 +18,29 @@ RUN pip3 install setuptools
 RUN pip3 install py4j
 RUN pip3 install pyspark
 RUN pip3 install numpy
+RUN pip3 install pandas
 
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      gcc \
+      git-core \
+      libffi-dev
+
+RUN pip3 install notebook
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      libjpeg-dev \
+      libpcre3 \
+      libpcre3-dev \
+      autoconf \
+      libtool \
+      pkg-config\
+      zlib1g-dev \
+      libssl-dev \
+      libexpat1-dev \
+      libxslt1.1\
+      gnuplot
+
+RUN pip3 install matplotlib
 
 HEALTHCHECK CMD curl -f http://localhost:9870/ || exit 1
 

--- a/nodemanager/Dockerfile
+++ b/nodemanager/Dockerfile
@@ -1,5 +1,9 @@
 FROM wxwmatt/hadoop-base:2.1.1-hadoop3.3.1-java8
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      python3.6
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
 HEALTHCHECK CMD curl -f http://localhost:8042/ || exit 1
 
 ADD run.sh /run.sh

--- a/resourcemanager/Dockerfile
+++ b/resourcemanager/Dockerfile
@@ -1,5 +1,9 @@
 FROM wxwmatt/hadoop-base:2.1.1-hadoop3.3.1-java8
 
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+      python3.6
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
 HEALTHCHECK CMD curl -f http://localhost:8088/ || exit 1
 
 ADD run.sh /run.sh


### PR DESCRIPTION
It would be really useful to have python installed in the containers, so that python scripts can be executed during invocation of mapred. 

- Add a build step to all the containers (for consistency)
- Install python 3 in each container
- Ensure python 3 is the default in each container